### PR TITLE
feat: 웹 폰트 세팅

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -2,11 +2,11 @@
 @import url("https://font.elice.io/css?family=Elice+Digital+Baeum");
 @import "tailwindcss";
 
-/* 
+
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-} */
+}
 
 .font-apple-gothic {
     font-family: 'Apple SD Gothic Neo', sans-serif;

--- a/app/app.css
+++ b/app/app.css
@@ -6,37 +6,14 @@
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
+    --font-apple-gothic: 'Apple SD Gothic Neo', sans-serif;
+    --font-sf: 'SF Pro Display', sans-serif;
+    --font-neo: 'NeoDunggeunmo', monospace;
+    --font-elice: 'Elice Digital Baeum', sans-serif;
+    --font-serif: 'Georgia', 'Times New Roman', serif;
+    --font-mono: 'Courier New', monospace;
+  }
 
-.font-apple-gothic {
-    font-family: 'Apple SD Gothic Neo', sans-serif;
-  }
-  
-  /* 여기서부터는 약어를 사용하도록 설정 */
-  .font-sf {
-    font-family: 'SF Pro Display', sans-serif;
-  }
-  
-  .font-neo {
-    font-family: 'NeoDunggeunmo', monospace;
-  }
-  
-  .font-elice {
-    font-family: 'Elice Digital Baeum', sans-serif;
-  }
-  
-  /* 기본 시스템 폰트 클래스 */
-  .font-sans {
-    font-family: 'Helvetica', 'Arial', sans-serif;
-  }
-  
-  .font-serif {
-    font-family: 'Georgia', 'Times New Roman', serif;
-  }
-  
-  .font-mono {
-    font-family: 'Courier New', monospace;
-  }
   
   /* 전역 기본 폰트 설정 */
   html, body {

--- a/app/app.css
+++ b/app/app.css
@@ -1,15 +1,45 @@
+@import url('//cdn.jsdelivr.net/gh/neodgm/neodgm-webfont@1.600/neodgm/style.css');
+@import url("https://font.elice.io/css?family=Elice+Digital+Baeum");
 @import "tailwindcss";
 
+/* 
 @theme {
   --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-}
+} */
 
-html,
-body {
-  /* @apply bg-white dark:bg-gray-950;
+.font-apple-gothic {
+    font-family: 'Apple SD Gothic Neo', sans-serif;
+  }
+  
+  /* 여기서부터는 약어를 사용하도록 설정 */
+  .font-sf {
+    font-family: 'SF Pro Display', sans-serif;
+  }
+  
+  .font-neo {
+    font-family: 'NeoDunggeunmo', monospace;
+  }
+  
+  .font-elice {
+    font-family: 'Elice Digital Baeum', sans-serif;
+  }
+  
+  /* 기본 시스템 폰트 클래스 */
+  .font-sans {
+    font-family: 'Helvetica', 'Arial', sans-serif;
+  }
+  
+  .font-serif {
+    font-family: 'Georgia', 'Times New Roman', serif;
+  }
+  
+  .font-mono {
+    font-family: 'Courier New', monospace;
+  }
+  
+  /* 전역 기본 폰트 설정 */
+  html, body {
+    font-family: 'Apple SD Gothic Neo', 'SF Pro Display', -apple-system, BlinkMacSystemFont, sans-serif;
+  }
 
-  @media (prefers-color-scheme: dark) {
-    color-scheme: dark;
-  } */
-}


### PR DESCRIPTION
## 변경사항
- Web fonts 관련 세팅 추가 (Apple SD Gothic Neo, SF Pro Display, NeoDunggeunmo, Elics DigitalBaeum)

## 변경 이유
- tailwind className으로 폰트를 간편하게 설정할 수 있도록 웹 폰트를 세팅합니다. (05-18 피그마 기준)

## 테스트 방법
<img width="377" alt="스크린샷 2025-05-18 오후 3 34 50" src="https://github.com/user-attachments/assets/75174d53-5a0f-48a8-934a-1f4c50bf7fbc" />
- className="font-elice" 와 같이 사용<br/>
- elice, neo와 같이 편의성을 위해 약어로 설정합니다. (#app.css 참고)