### PR TITLE
캐러셀 내부 UI 수정 및 모드 추가

### DIFF
--- a/app/routes/result/result.tsx
+++ b/app/routes/result/result.tsx
@@ -90,7 +90,7 @@ export default function ResultPage() {
   ];
 
   return (
-    <div className="h-full w-full bg-[#181818] p-4">
+    <div className="h-full w-full">
       <CarouselContainer slides={slides} fullWidthSlide={true} />
       <div className="m-10 flex h-[46px] flex-row items-center justify-center gap-x-[10px]">
         <button

--- a/app/shared/components/carousel/carousel-container.tsx
+++ b/app/shared/components/carousel/carousel-container.tsx
@@ -17,6 +17,7 @@ const CarouselContainer: React.FC<CarouselContainerProps> = ({
   return (
     <div className="mx-auto w-full max-w-lg">
       <Carousel
+        theme="dark"
         slides={slides}
         options={options}
         fullWidthSlide={fullWidthSlide}

--- a/app/shared/components/carousel/carousel-container.tsx
+++ b/app/shared/components/carousel/carousel-container.tsx
@@ -5,7 +5,6 @@ import Carousel from ".";
 type CarouselContainerProps = {
   slides: CarouselSlide[];
   options?: EmblaOptionsType;
-  showArrows?: boolean;
   fullWidthSlide?: boolean;
 };
 

--- a/app/shared/components/carousel/index.tsx
+++ b/app/shared/components/carousel/index.tsx
@@ -1,7 +1,6 @@
 import type { EmblaOptionsType } from "embla-carousel";
 import useEmblaCarousel from "embla-carousel-react";
 import { useEffect, useState } from "react";
-import { usePrevNextButtons } from "./carousel-buttons";
 
 export type CarouselSlide = {
   id: number;
@@ -12,7 +11,6 @@ export type CarouselSlide = {
 type CarouselProps = {
   slides: CarouselSlide[];
   options?: EmblaOptionsType;
-  showArrows?: boolean;
   // 이미지만 보이는 모드에서는 false, 화살표가 필요한 모드에서는 true로 설정해서 사용해주세요!
   fullWidthSlide?: boolean;
   onSelectIndexChange?: (index: number) => void;
@@ -21,15 +19,8 @@ type CarouselProps = {
 
 const Carousel: React.FC<CarouselProps> = (props) => {
   const { slides, options, fullWidthSlide } = props;
-  const showArrows = props.showArrows ?? fullWidthSlide;
   const theme = props.theme ?? "dark";
   const [emblaRef, emblaApi] = useEmblaCarousel(options);
-  const {
-    prevBtnDisabled,
-    nextBtnDisabled,
-    onPrevButtonClick,
-    onNextButtonClick,
-  } = usePrevNextButtons(emblaApi);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   useEffect(() => {
@@ -57,21 +48,21 @@ const Carousel: React.FC<CarouselProps> = (props) => {
 
   return (
     <section className="mx-auto">
-      <div className="">
-        <div className="overflow-hidden" ref={emblaRef}>
-          <div className={`flex ${!fullWidthSlide ? "-ml-4" : ""}`}>
+      <div
+        className={`relative mx-auto ${fullWidthSlide ? "h-[670px] w-[375px]" : "h-[560px]"}`}
+      >
+        <div className="h-full overflow-hidden" ref={emblaRef}>
+          <div className={`flex h-full ${!fullWidthSlide ? "-ml-4" : ""}`}>
             {slides.map((slide, index) => (
               <div
                 className={`
-                  ${fullWidthSlide ? "w-full flex-none" : "flex-none pl-4"} max-h-full min-w-0 transform-gpu px-2 `}
+                  ${fullWidthSlide ? "w-full flex-none" : "w-[330px] flex-none bg-gray-200 pl-4"} h-full min-w-0 transform-gpu`}
                 key={slide.id}
               >
-                <div className="relative mx-auto aspect-[4/3] h-[511px] w-[306px]">
+                <div className="relative">
                   <img
-                    className={`h-full w-full rounded-md object-cover transition-all duration-300 ${
-                      selectedIndex === index
-                        ? "opacity-100 blur-0"
-                        : "opacity-70 blur-sm"
+                    className={`h-full w-full object-cover transition-all duration-300 ${
+                      selectedIndex === index ? "opacity-100" : "opacity-60"
                     }
                   `}
                     src={slide.image}
@@ -82,17 +73,15 @@ const Carousel: React.FC<CarouselProps> = (props) => {
             ))}
           </div>
         </div>
-        <div className="mx-auto mt-4 flex w-full max-w-[150px] items-center justify-center">
-          <div className="mt-2 flex cursor-pointer items-center justify-center space-x-2">
-            {slides.map((slide, index) => (
-              <button
-                type="button"
-                key={slide.id}
-                onClick={() => emblaApi?.scrollTo(index)}
-                className={`h-2 w-2 rounded-full transition-colors duration-200 ${getButtonColors(selectedIndex === index)}`}
-              />
-            ))}
-          </div>
+        <div className="-translate-x-1/2 absolute bottom-4 left-1/2 z-10 flex cursor-pointer items-center justify-center space-x-2">
+          {slides.map((slide, index) => (
+            <button
+              type="button"
+              key={slide.id}
+              onClick={() => emblaApi?.scrollTo(index)}
+              className={`h-2 w-2 rounded-full transition-colors duration-200 ${getButtonColors(selectedIndex === index)}`}
+            />
+          ))}
         </div>
       </div>
     </section>

--- a/app/shared/components/carousel/index.tsx
+++ b/app/shared/components/carousel/index.tsx
@@ -1,7 +1,7 @@
 import type { EmblaOptionsType } from "embla-carousel";
 import useEmblaCarousel from "embla-carousel-react";
 import { useEffect, useState } from "react";
-import { NextButton, PrevButton, usePrevNextButtons } from "./carousel-buttons";
+import { usePrevNextButtons } from "./carousel-buttons";
 
 export type CarouselSlide = {
   id: number;
@@ -16,11 +16,13 @@ type CarouselProps = {
   // 이미지만 보이는 모드에서는 false, 화살표가 필요한 모드에서는 true로 설정해서 사용해주세요!
   fullWidthSlide?: boolean;
   onSelectIndexChange?: (index: number) => void;
+  theme?: "light" | "dark";
 };
 
 const Carousel: React.FC<CarouselProps> = (props) => {
   const { slides, options, fullWidthSlide } = props;
   const showArrows = props.showArrows ?? fullWidthSlide;
+  const theme = props.theme ?? "dark";
   const [emblaRef, emblaApi] = useEmblaCarousel(options);
   const {
     prevBtnDisabled,
@@ -45,6 +47,13 @@ const Carousel: React.FC<CarouselProps> = (props) => {
       emblaApi?.off("select", onSelect);
     };
   }, [emblaApi, props.onSelectIndexChange]);
+
+  const getButtonColors = (isSelected: boolean) => {
+    if (theme === "light") {
+      return isSelected ? "bg-[#373737]" : "bg-white";
+    }
+    return isSelected ? "bg-white" : "bg-[#373737]";
+  };
 
   return (
     <section className="mx-auto">
@@ -73,36 +82,33 @@ const Carousel: React.FC<CarouselProps> = (props) => {
             ))}
           </div>
         </div>
-        <div className="mx-auto mt-4 flex w-full max-w-[150px] items-center justify-between">
-          <div className="flex w-8 justify-center">
+        <div className="mx-auto mt-4 flex w-full max-w-[150px] items-center justify-center">
+          {/* <div className="flex w-8 justify-center">
             {showArrows && (
               <PrevButton
                 onClick={onPrevButtonClick}
                 disabled={prevBtnDisabled}
               />
             )}
-          </div>
-          <div className="mt-2 flex items-center justify-center space-x-2">
+          </div> */}
+          <div className="mt-2 flex cursor-pointer items-center justify-center space-x-2">
             {slides.map((slide, index) => (
               <button
                 type="button"
                 key={slide.id}
                 onClick={() => emblaApi?.scrollTo(index)}
-                className={`h-2 w-2 rounded-full ${
-                  selectedIndex === index ? "bg-white" : "bg-[#373737]"
-                }
-                      `}
+                className={`h-2 w-2 rounded-full transition-colors duration-200 ${getButtonColors(selectedIndex === index)}`}
               />
             ))}
           </div>
-          <div className="flex w-8 justify-center">
+          {/* <div className="flex w-8 justify-center">
             {showArrows && (
               <NextButton
                 onClick={onNextButtonClick}
                 disabled={nextBtnDisabled}
               />
             )}
-          </div>
+          </div> */}
         </div>
       </div>
     </section>

--- a/app/shared/components/carousel/index.tsx
+++ b/app/shared/components/carousel/index.tsx
@@ -83,14 +83,6 @@ const Carousel: React.FC<CarouselProps> = (props) => {
           </div>
         </div>
         <div className="mx-auto mt-4 flex w-full max-w-[150px] items-center justify-center">
-          {/* <div className="flex w-8 justify-center">
-            {showArrows && (
-              <PrevButton
-                onClick={onPrevButtonClick}
-                disabled={prevBtnDisabled}
-              />
-            )}
-          </div> */}
           <div className="mt-2 flex cursor-pointer items-center justify-center space-x-2">
             {slides.map((slide, index) => (
               <button
@@ -101,14 +93,6 @@ const Carousel: React.FC<CarouselProps> = (props) => {
               />
             ))}
           </div>
-          {/* <div className="flex w-8 justify-center">
-            {showArrows && (
-              <NextButton
-                onClick={onNextButtonClick}
-                disabled={nextBtnDisabled}
-              />
-            )}
-          </div> */}
         </div>
       </div>
     </section>


### PR DESCRIPTION
## 🔀 PR 내용 요약
- 캐러셀 내부에 light/dark mode 분기 처리를 추가합니다. (중간 페이지에서는 light / 결과 페이지에서는 dark mode 사용)
- 캐러셀 내부 UI를 수정합니다. (fullWidthSlide or not)


## ✅ 작업 내용
- carousel에 theme prop 추가
- fullWidthSlide일 때 / 아닐 때 관련 UI 수정
- (기타) 디자인 변경에 따라 캐러셀에서 arrow 관련 조건은 모두 삭제

## 💡 체크리스트
<!-- PR을 제출하기 전에 아래 항목들을 확인해주세요. -->
- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 테스트는 잘 통과했나요?
- [x] 본인을 assign 해주세요.
- [x] 리뷰어를 지정했나요?
- [x] 빌드에 성공했나요?