### PR TITLE
feat: bottomSheet 너비 조정

### DIFF
--- a/app/shared/components/bottomSheet/bottom-sheet.tsx
+++ b/app/shared/components/bottomSheet/bottom-sheet.tsx
@@ -26,7 +26,7 @@ function BottomSheet({
   onClose,
   children,
   // className = "",
-  width = "w-[359px]",
+  width,
 }: ShareBottomSheetProps) {
   const [_, setIsVisible] = useState(false);
   const sheetRef = useRef<HTMLDivElement>(null);
@@ -77,9 +77,14 @@ function BottomSheet({
       />
       {/* 시트 */}
       <div
-        className={`pointer-events-auto relative ${width} max-w-md transform rounded-t-2xl bg-[#212121] py-[8px] shadow-2xl transition-transform duration-300 ${
+        className={`pointer-events-auto relative w-[359px] max-w-[678px] transform rounded-t-2xl bg-[#212121] py-[8px] shadow-2xl transition-transform duration-300 ${
           isOpen ? "translate-y-0" : "translate-y-full"
-        }`}
+        } ${width || ""}`}
+        style={{
+          width: width
+            ? undefined
+            : "clamp(359px, calc(359px + (100vw - 375px) * (678 - 359) / (700 - 375)), 678px)",
+        }}
         ref={sheetRef}
         role="alert"
         aria-modal="true"


### PR DESCRIPTION
## 🔀 PR 내용 요약
<!-- 작업 개요를 간단히 작성하고, 관련된 이슈가 있다면 이슈 번호를 연결해주세요. -->
- 작업 개요: bottomSheet 너비 조정


## ✅ 작업 내용
- CSS clamp 함수를 활용해 설정함
: 모든 모던 브라우저에서 지원 & 모바일 디바이스 최적화

**바텀시트 반응형 너비 적용**
375px 기준: 359px 고정
700px 이상: 최대 678px 제한
375-700px 사이: CSS clamp() 함수를 사용해 비율 조정

**반응형 디자인 구현**
부드러운 너비 전환 +
화면 크기에 따라 자연스럽게 바텀시트 크기 조정 O
기존 width prop 호환성 유지하도록 set



## 📸 스크린샷 / 데모 (옵션)
**375px 기준**
<img width="1487" height="992" alt="스크린샷 2025-07-16 오후 7 07 16" src="https://github.com/user-attachments/assets/9dcd1b38-b830-4285-a48b-58653d904e1a" />

**중간**
<img width="1479" height="991" alt="스크린샷 2025-07-16 오후 7 07 24" src="https://github.com/user-attachments/assets/d0c15c70-e5aa-404a-b3ed-a281446dc51f" />


**max 크기 678px**
<img width="1449" height="853" alt="스크린샷 2025-07-16 오후 7 07 05" src="https://github.com/user-attachments/assets/ad0a7284-dab9-4056-a1c9-5cfef2ee3b72" />