### PR TITLE
feat: 결과 페이지로 데이터를 넘길 때 에러 페이지가 뜨는 이슈 핸들링

### DIFF
--- a/app/routes/result/result.tsx
+++ b/app/routes/result/result.tsx
@@ -1,5 +1,5 @@
 import { useControllableState } from "@radix-ui/react-use-controllable-state";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router";
 import {
   useEvaluationControllerCheckIfGuestUserUseChance,
@@ -405,6 +405,21 @@ export default function ResultPage() {
   // 조건부 반환문들을 모든 Hook 이후에 배치
   if (isLoading) {
     return <div>로딩중</div>;
+  }
+
+  // evaluationId가 없는 경우만 홈으로 리다이렉트
+  if (!evaluationId) {
+    useEffect(() => {
+      navigate("/");
+    }, [navigate]);
+    return <div>잘못된 접근입니다.</div>;
+  }
+
+  if (!isLoading && !evaluationData?.data) {
+    useEffect(() => {
+      navigate("/");
+    }, [navigate]);
+    return <div>데이터를 찾을 수 없습니다.</div>;
   }
 
   if (error && evaluationId) {


### PR DESCRIPTION
## 🔀 PR 내용 요약
<!-- 작업 개요를 간단히 작성하고, 관련된 이슈가 있다면 이슈 번호를 연결해주세요. -->
- 작업 개요: 결과 페이지 데이터 없음 에러 처리 개선

## ✅ 작업 내용
<!-- 구현한 기능이나 수정한 내용을 상세히 기술해주세요. -->
**결과 페이지 데이터 없음 에러 처리 개선**
문제: 중간 페이지에서 결과 페이지로 이동 시 데이터가 없는 경우 에러 페이지를 거쳐 결과 페이지로 넘어가는 이슈
해결: 데이터 유효성 검사를 통한 즉시 홈 리다이렉트 처리
(1) evaluationId가 없는 경우
(2) API 호출 완료 후 데이터가 없는 경우

`AS-IS`: 에러 페이지 → 결과 페이지
`TO-BE`: 데이터 없음 → 즉시 홈 리다이렉트