### PR TITLE
fix: 강도 선택 넘버링 수정 및 spicyLevel 유효값 타입 제한과 값 수정

### DIFF
--- a/app/routes/analyze/analyze.tsx
+++ b/app/routes/analyze/analyze.tsx
@@ -23,7 +23,7 @@ import StickersBackground from "./image-studio/stickers-background";
 import IntensitySelectPage from "./intensity-select";
 
 const analyzeSchema = z.object({
-  spicyLevel: z.number(),
+  spicyLevel: z.number().min(1).max(3),
   imageId: z.number(),
 });
 

--- a/app/routes/analyze/intensity/intensity-item.tsx
+++ b/app/routes/analyze/intensity/intensity-item.tsx
@@ -7,6 +7,7 @@ import { cn } from "~/shared/utils/classname-utils";
 
 export default function IntensityItem({ intensity }: { intensity: Intensity }) {
   const {
+    id,
     MainIcon,
     level,
     value,
@@ -25,7 +26,7 @@ export default function IntensityItem({ intensity }: { intensity: Intensity }) {
       <div className="flex h-full flex-col items-center p-10 pb-13.5 font-elice">
         <div className="flex w-full items-start justify-between">
           <div className="relative w-fit font-bold text-xl xs:text-2xl">
-            <div className={colorClassName.darkText}>No.{level + 1}</div>
+            <div className={colorClassName.darkText}>No.{id}</div>
             <Highlight className="-top-1/3 -left-2/5 absolute h-[190%] w-[200%]" />
           </div>
 

--- a/app/shared/consts/intensity.ts
+++ b/app/shared/consts/intensity.ts
@@ -66,7 +66,7 @@ export const intensities: Intensity[] = [
   {
     id: 3,
     value: "easy",
-    level: 0,
+    level: 1,
     MainIcon: HeartShape,
     discription: "다정하고 칭찬을 아끼지 않는 패션 입문자를 위한 평가 버전",
     colorClassName: {


### PR DESCRIPTION
## 🔀 PR 내용 요약
<!-- 작업 개요를 간단히 작성하고, 관련된 이슈가 있다면 이슈 번호를 연결해주세요. -->
- 작업 개요: 강도 선택 넘버링 오타를 수정하였습니다. 또한 `spicyLevel`이 0, 1, 2 만 가능하도록 유효값을 `zod`로 검증하고, 잘못된 `spicyLevel` 값을 수정하였습니다.
